### PR TITLE
Allow/Disallow nested transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,1 @@
-*.DS_Store
-core/local.properties
-core/bin/
-core/gen/
-example-v1/local.properties
-example-v1/bin/
-example-v1/gen/
-example-v2/local.properties
-example-v2/bin/
-example-v2/gen/
-example-v3/local.properties
-example-v3/bin/
-example-v3/gen/
+.directory

--- a/core/src/com/readystatesoftware/sqliteasset/SQLiteAssetHelper.java
+++ b/core/src/com/readystatesoftware/sqliteasset/SQLiteAssetHelper.java
@@ -75,6 +75,9 @@ public class SQLiteAssetHelper extends SQLiteOpenHelper {
 	private String mArchivePath;
 	private String mUpgradePathFormat;
 	
+	private static final String BEGIN_TRANSACTION = "begin transaction";
+	private static final String COMMIT_TRANSACTION = "commit transaction";
+	
 	private int mForcedUpgradeVersion = 0;
 	
 	 /**
@@ -207,20 +210,20 @@ public class SQLiteAssetHelper extends SQLiteOpenHelper {
 			return false;
 		}
 		
-		trimmedCmd =  cmd.trim();
+		trimmedCmd = cmd.trim().toLowerCase();
 		
 		if(trimmedCmd.length() <= 0){
 			return false;
 		}
 		
 		if(!mAllowNestedTransactions){
-			if(trimmedCmd.endsWith("BEGIN TRANSACTION")){
+			if(trimmedCmd.endsWith(BEGIN_TRANSACTION)){
 				return false;
 			}
-			if("BEGIN TRANSACTION".equals(trimmedCmd)){
+			if(BEGIN_TRANSACTION.equals(trimmedCmd)){
 				return false;
 			}
-			if("COMMIT TRANSACTION".equals(trimmedCmd)){
+			if(COMMIT_TRANSACTION.equals(trimmedCmd)){
 				return false;
 			}
 		}


### PR DESCRIPTION
As I kept forgetting to remove the "BEGIN TRANSACTION" and "COMMIT TRANSACTION" lines of the migration script produced by  the SQLite Compare Utility, I made the library's default behaviour to skip them.

This will essentially treat any nested transactions in the migration script as part of the parent one.

If someone _really_ wants to, nested transactions can be re-enabled by calling "setAllowNestedTransactions(true)".

(I told you I am bad at repetitive tasks)

-Alex
