### PR TITLE
Properly split SQL script; fixes #47

### DIFF
--- a/library/src/main/java/com/readystatesoftware/sqliteasset/Utils.java
+++ b/library/src/main/java/com/readystatesoftware/sqliteasset/Utils.java
@@ -42,7 +42,12 @@ class Utils {
             } else {
                 sb.append(content[i]);
             }
-            lastCharacter = content[i];
+            if (lastCharacter == '\\' && content[i] == '\\') {
+                // It was an escaped backslash, don't accumulate.
+                lastCharacter = -1;
+            } else {
+                lastCharacter = content[i];
+            }
         }
         if (sb.length() > 0) {
             statements.add(sb.toString().trim());


### PR DESCRIPTION
This adds support for single quote string delimiters (as is the default with SQLite's own .dump command) and for escaped delimiters inside strings.
