### PR TITLE
don't skip .sql upgrade scipts after a forced upgrade if the bundled database file is not the latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:0.7.+"
+        classpath 'com.android.tools.build:gradle:1.5.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Wed Jan 13 15:54:05 GMT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,7 +1,7 @@
-apply plugin: 'android-library'
+apply plugin: 'com.android.library'
 
 android {
-    buildToolsVersion '19.0.0'
+    buildToolsVersion '19.1.0'
     compileSdkVersion 19
 
     defaultConfig {
@@ -11,7 +11,7 @@ android {
 
 android.libraryVariants.all { variant ->
     def name = variant.buildType.name
-    if (name.equals(com.android.builder.BuilderConstants.DEBUG)) {
+    if (name.equals(com.android.builder.core.BuilderConstants.DEBUG)) {
         return; // Skip debug builds.
     }
     def task = project.tasks.create "jar${name.capitalize()}", Jar

--- a/library/src/main/java/com/readystatesoftware/sqliteasset/SQLiteAssetHelper.java
+++ b/library/src/main/java/com/readystatesoftware/sqliteasset/SQLiteAssetHelper.java
@@ -179,6 +179,8 @@ public class SQLiteAssetHelper extends SQLiteOpenHelper {
 
             // do force upgrade
             if (version != 0 && version < mForcedUpgradeVersion) {
+                //Close the old database
+                db.close();
                 db = createOrOpenDatabase(true);
                 db.setVersion(mNewVersion);
                 version = db.getVersion();

--- a/library/src/main/java/com/readystatesoftware/sqliteasset/SQLiteAssetHelper.java
+++ b/library/src/main/java/com/readystatesoftware/sqliteasset/SQLiteAssetHelper.java
@@ -182,8 +182,10 @@ public class SQLiteAssetHelper extends SQLiteOpenHelper {
                 //Close the old database
                 db.close();
                 db = createOrOpenDatabase(true);
-                db.setVersion(mNewVersion);
+                Log.w(TAG, "Forced Upgrade because " + version + " < " + mForcedUpgradeVersion);
                 version = db.getVersion();
+                if(version != mNewVersion)
+                    Log.w(TAG, "Forced Upgrade got " + version + ", now an upgrade to " + mNewVersion + " is required");
             }
 
             if (version != mNewVersion) {

--- a/samples/database-v1/build.gradle
+++ b/samples/database-v1/build.gradle
@@ -1,16 +1,16 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 dependencies {
     compile project(':library')
 }
 
 android {
-    buildToolsVersion '19.0.0'
+    buildToolsVersion '19.1.0'
     compileSdkVersion 19
 
     defaultConfig {
         minSdkVersion 8
-        packageName 'com.example.sqliteassethelper'
+        applicationId 'com.example.sqliteassethelper'
         targetSdkVersion 19
         versionCode 1
         versionName '1.0'

--- a/samples/database-v13-upgrade/build.gradle
+++ b/samples/database-v13-upgrade/build.gradle
@@ -2,11 +2,8 @@ buildscript {
     repositories {
         mavenCentral()
     }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:0.7.+'
-    }
 }
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 repositories {
     mavenCentral()
@@ -14,7 +11,7 @@ repositories {
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "19.1.0"
 
     defaultConfig {
         minSdkVersion 8
@@ -24,7 +21,7 @@ android {
     }
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/samples/database-v2-upgrade/build.gradle
+++ b/samples/database-v2-upgrade/build.gradle
@@ -1,16 +1,16 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 dependencies {
     compile project(':library')
 }
 
 android {
-    buildToolsVersion '19.0.0'
+    buildToolsVersion '19.1.0'
     compileSdkVersion 19
 
     defaultConfig {
         minSdkVersion 8
-        packageName 'com.example.sqliteassethelper'
+        applicationId 'com.example.sqliteassethelper'
         targetSdkVersion 19
         versionCode 2
         versionName '2.0'


### PR DESCRIPTION
I don't always update the bundled .db file when I add a new schema version but instead I add an upgrade script .sql file (e.g. database.db_upgrade_2-3.sql) and accodingly increment (e.g. 2->3) the version parameter when calling the super constructor `SQLiteAssetHelper(...)`.
This way existing installs use the .sql script as usual and new installs copy the bundled database.db (version 2) and then execute the .sql upgrade on top of that.

I found a problem when I use setForcedUpgrade(2), now updates from version 1 to 3 would replace the old version 1 database with the bundled version 2 (like expected), but not apply the version 3 upgrade .sql file and instead just set the version to 3.

I found that the code in `getWritableDatabase()` blindly overrides the version of the newly copied database to be the latest version mNewVersion that had been defined by calling the super constructor.
I based this PR on top of #87 because that is also related to using setForcedUpgrade().
The main change in this PR is to remove the line `db.setVersion(mNewVersion);` in order to still trigger the version check and upgrade using .sql files if the bundled sqlite.db file is "outdated".